### PR TITLE
Fix a link

### DIFF
--- a/docs/overview.html
+++ b/docs/overview.html
@@ -366,7 +366,7 @@ KotlinPlayground('.lang-kotlin');
 <p>以下を参考にして作成されています。</p>
 <ul>
 <li><a href="https://www.amazon.co.jp/dp/B06XHJMR65/ref=dp-kindle-redirect?_encoding=UTF8&amp;btkr=1" target="_blank">Kotlin スタートブック</a></li>
-<li><a href="http://kotlinlang.org/docs/reference/" target="_blank">Reference - Kotlin Programming Language</a></li>
+<li><a href="https://kotlinlang.org/docs/home.html" target="_blank">Kotlin Docs</a></li>
 <li><a href="https://github.com/Kotlin/kotlin-koans" target="_blank">Kotlin koans</a><ul>
 <li>たくさん課題があるので、一通りやってみるととても良い！</li>
 </ul>

--- a/src/overview.md
+++ b/src/overview.md
@@ -15,6 +15,6 @@ https://github.com/access-company/kotlin_intro/
 以下を参考にして作成されています。
 
 * [Kotlin スタートブック](https://www.amazon.co.jp/dp/B06XHJMR65/ref=dp-kindle-redirect?_encoding=UTF8&btkr=1)
-* [Reference - Kotlin Programming Language](http://kotlinlang.org/docs/reference/)
+* [Kotlin Docs](https://kotlinlang.org/docs/home.html)
 * [Kotlin koans](https://github.com/Kotlin/kotlin-koans)
   * たくさん課題があるので、一通りやってみるととても良い！


### PR DESCRIPTION
## Pull Request for issue #41 

## 更新内容
[はじめに](https://access-company.github.io/kotlin_intro/overview.html)の[Reference - Kotlin Programming Language](http://kotlinlang.org/docs/reference/)がリンク切れしておりhttpなので、[Kotlin Docs](https://kotlinlang.org/docs/home.html)へのリンクに修正