### PR TITLE
update Kotlin version

### DIFF
--- a/docs/about_kotlin.html
+++ b/docs/about_kotlin.html
@@ -361,9 +361,9 @@ KotlinPlayground('.lang-kotlin');
 <li>ライセンスは Apache 2.0</li>
 </ul>
 </li>
-<li>2021年4月現在、Kotlin はバージョン 1.4<ul>
-<li><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.4.31" target="_blank">1.4.31</a> が最新</li>
-<li>プレビュー版としては <a href="https://github.com/JetBrains/kotlin/releases/tag/v1.5.0-M1" target="_blank">1.5.0-M1</a> あたりが出ている</li>
+<li>2022年3月14日現在、Kotlin はバージョン 1.6<ul>
+<li><a href="https://github.com/JetBrains/kotlin/releases/tag/v1.6.10" target="_blank">1.6.10</a> が最新</li>
+<li>プレビュー版としては <a href="https://github.com/JetBrains/kotlin/releases/tag/v1.6.20-M1" target="_blank">1.6.20-M1</a> あたりが出ている</li>
 </ul>
 </li>
 </ul>

--- a/src/about_kotlin.md
+++ b/src/about_kotlin.md
@@ -5,9 +5,9 @@
 * JetBrains 社が中心となって開発を行っているプログラミング言語
 * 2011年夏に発表。現在は OSS ([github のリポジトリ](https://github.com/JetBrains/kotlin)) として開発されている
   * ライセンスは Apache 2.0
-* 2021年4月現在、Kotlin はバージョン 1.4
-  * [1.4.31](https://github.com/JetBrains/kotlin/releases/tag/v1.4.31) が最新
-  * プレビュー版としては [1.5.0-M1](https://github.com/JetBrains/kotlin/releases/tag/v1.5.0-M1) あたりが出ている
+* 2022年3月14日現在、Kotlin はバージョン 1.6
+  * [1.6.10](https://github.com/JetBrains/kotlin/releases/tag/v1.6.10) が最新
+  * プレビュー版としては [1.6.20-M1](https://github.com/JetBrains/kotlin/releases/tag/v1.6.20-M1) あたりが出ている
 
 ## どんな言語か
 


### PR DESCRIPTION
## Pull Request for issue #47

## Reopen #51

## 更新内容
「[Kotlinについて](../blob/master/src/about_kotlin.md)」に書いてあるKotlinの最新安定版と最新プレビュー版の数字を、それぞれ2022/3/14現在の1.6.10と1.6.20_M1に更新
